### PR TITLE
Add GitHub Workflow with CI Jobs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,72 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main", "develop"]
+
+jobs:
+  type-check:
+    name: type-check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: yarn
+      - run: yarn lint
+
+  typetest:
+    name: typetest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: yarn
+      - run: yarn typetest
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: yarn
+      - run: yarn test
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: yarn
+      - run: yarn build

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 <p align="center">
     <a href="https://github.com/drizzer14/fnts/blob/main/LICENSE">
-      <img src="https://img.shields.io/github/license/drizzer14/fnts" />
+      <img src="https://img.shields.io/github/license/drizzer14/fnts?color=blue&style=for-the-badge" />
     </a>
-    <a href="https://travis-ci.com/github/drizzer14/fnts">
-      <img src="https://img.shields.io/travis/com/drizzer14/fnts" />
+    <a href="https://github.com/drizzer14/fnts/actions/workflows/workflow.yml">
+      <img src="https://img.shields.io/github/actions/workflow/status/drizzer14/fnts/workflow.yml?color=blue&style=for-the-badge" />
     </a>
     <a href="https://www.npmjs.com/package/fnts">
-      <img src="https://img.shields.io/npm/v/fnts" />
+      <img src="https://img.shields.io/npm/v/fnts?color=blue&style=for-the-badge" />
     </a>
 </p>
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:coverage": "jest --coverage",
     "ci": "npm-run-all -s build lint test typetest",
     "bump": "standard-version",
-    "prepublish": "node scripts/prepublish.js",
+    "prepublishOnly": "node scripts/prepublish.js",
     "publish": "yarn publish lib --non-interactive",
     "release": "npm-run-all -s build publish"
   },


### PR DESCRIPTION
This setup enhances the CI process by ensuring code quality and build integrity across key branches:
- added a GitHub Actions workflow to automate CI tasks
- configured the workflow to trigger on **push** to `main` and on **pull_request** to `main` or `develop`
- set up a badge to display workflow status in the readme

The workflow includes 4 separate jobs:
- **type-check**
- **typetest**
- **test**
- **build**

The automatic launch of CI in a pull request should look like this:
<img width="928" alt="Screenshot 2024-08-19 at 11 12 32 PM" src="https://github.com/user-attachments/assets/8bb707f6-03e5-49ef-8464-e7c20be19653">